### PR TITLE
Refactor HTTP server to reuse client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This repository contains the code for the implementation of an API Gateway for O
 Follow the instructions for installing [Hertz](https://www.cloudwego.io/docs/hertz/getting-started/) and
 [Kitex](https://www.cloudwego.io/docs/kitex/getting-started/).
 
+Install the [thrift-gen-validator](https://github.com/cloudwego/thrift-gen-validator).
+
 ### Installing etcd
 
 - Download the latest version of `etcd` from the **Releases** [page](https://github.com/etcd-io/etcd/releases/).
@@ -98,7 +100,7 @@ To generate the RPC Server scaffolding code from template, run the following com
 $ mkdir NEW_DIRECTORY
 $ cd NEW_DIRECTORY
 $ kitex -module "github.com/tim-pipi/cloudwego-api-gateway/NEW_DIRECTORY" --template-dir
- ../templates ../idl/hello_api.thrift
+ ../templates --thrift-plugin validator ../idl/hello_api.thrift
 go: creating new go.mod: module github.com/tim-pipi/cloudwego-api-gateway/test
 Adding apache/thrift@v0.13.0 to go.mod for generated code .......... Done
 $ go mod tidy

--- a/http-server/clientpool/clientpool.go
+++ b/http-server/clientpool/clientpool.go
@@ -1,0 +1,124 @@
+package clientpool
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+	kclient "github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/client/genericclient"
+	"github.com/cloudwego/kitex/pkg/generic"
+	"github.com/cloudwego/kitex/pkg/klog"
+	"github.com/cloudwego/kitex/pkg/loadbalance"
+	etcd "github.com/kitex-contrib/registry-etcd"
+)
+
+type ClientPool struct {
+	serviceMap map[string]genericclient.Client
+	mutex      sync.Mutex
+}
+
+var (
+	clientPool = &ClientPool{
+		serviceMap: make(map[string]genericclient.Client),
+	}
+)
+
+// Performs the generic call to the RPC server
+// Calls the same client for the same service name
+func Call(ctx context.Context, c *app.RequestContext, idlPath string) {
+	jsonBody := string(c.Request.BodyBytes())
+	klog.Info("Request Body: ", jsonBody)
+
+	cli := getClient(c, idlPath)
+	serviceMethod := getServiceMethod(c)
+
+	// Make the Generic Call
+	resp, err := cli.GenericCall(ctx, serviceMethod, jsonBody)
+	if err != nil {
+		klog.Info("remote procedure call failed: %v", err)
+		// Retries the request if error
+		// This is because the connection to the RPC server has a timeout
+		// if the connection is idle for a long time.
+		resp, _ = cli.GenericCall(ctx, serviceMethod, jsonBody)
+	}
+	klog.Info("Response body: ", resp)
+
+	respString, ok := resp.(string)
+	if !ok {
+		klog.Error("Response is not a string:", resp)
+	}
+
+	c.String(consts.StatusOK, respString)
+	c.SetContentType("application/json")
+}
+
+// getClient returns the same client for the same service name
+func getClient(c *app.RequestContext, idlPath string) genericclient.Client {
+	clientPool.mutex.Lock()
+	defer clientPool.mutex.Unlock()
+
+	serviceName := getServiceName(c)
+	client, ok := clientPool.serviceMap[serviceName]
+
+	if !ok {
+		client = newClient(idlPath, serviceName)
+		clientPool.serviceMap[serviceName] = client
+	}
+
+	return client
+}
+
+// getServiceName returns the service name from the full path of the url
+func getServiceName(c *app.RequestContext) string {
+	fullPath := c.FullPath()
+
+	service := strings.Split(fullPath, "/")
+	serviceName := service[1]
+	klog.Info("Service Name: ", serviceName)
+
+	return serviceName
+}
+
+// getServiceMethod returns the service method from the full path of the url
+func getServiceMethod(c *app.RequestContext) string {
+	fullPath := c.FullPath()
+
+	service := strings.Split(fullPath, "/")
+	serviceMethod := service[2]
+	klog.Info("Service Method: ", serviceMethod)
+
+	return serviceMethod
+}
+
+func newClient(idlPath string, serviceName string) genericclient.Client {
+	p, err := generic.NewThriftFileProvider(idlPath)
+	if err != nil {
+		klog.Fatalf("new thrift file provider failed: %v", err)
+	}
+
+	g, err := generic.JSONThriftGeneric(p)
+	if err != nil {
+		klog.Fatalf("new http pb thrift generic failed: %v", err)
+	}
+
+	r, err := etcd.NewEtcdResolver([]string{"localhost:2379"})
+	if err != nil {
+		klog.Fatalf("new etcd resolver failed: %v", err)
+	}
+
+	lb := loadbalance.NewWeightedRoundRobinBalancer()
+
+	cli, err := genericclient.NewClient(serviceName, g,
+		kclient.WithResolver(r),
+		kclient.WithLoadBalancer(lb),
+	)
+
+	if err != nil {
+		klog.Fatalf("new http generic client failed: %v", err)
+	}
+
+	return cli
+}

--- a/idl/hello_api.thrift
+++ b/idl/hello_api.thrift
@@ -9,7 +9,7 @@ struct HelloResp {
 }
 
 struct EchoReq {
-    1: required string message
+    1: required string message (vt.min_size = "1")
 }
 
 struct EchoResp {

--- a/rpc-server/handler.go
+++ b/rpc-server/handler.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
-	api "github.com/tim-pipi/cloudwego-api-gateway/rpc-server/kitex_gen/api"
+	"fmt"
+
 	"github.com/cloudwego/kitex/pkg/klog"
+	api "github.com/tim-pipi/cloudwego-api-gateway/rpc-server/kitex_gen/api"
 )
 
 var _ = klog.Info
@@ -13,7 +15,11 @@ type HelloServiceImpl struct{}
 
 // HelloMethod implements the HelloServiceImpl interface.
 func (s *HelloServiceImpl) HelloMethod(ctx context.Context, request *api.HelloReq) (resp *api.HelloResp, err error) {
-	// TODO: Your code here...
+	if request.Name == "" {
+		err = fmt.Errorf("name is required")
+		return
+	}	
+	
 	resp = &api.HelloResp{
 		RespBody: "hello, " + request.Name,
 	}

--- a/rpc-server/main.go
+++ b/rpc-server/main.go
@@ -48,7 +48,7 @@ func main() {
 			}),
 			server.WithServiceAddr(addr),
 			server.WithMiddleware(middleware.MiddleWareLogger(fmt.Sprintf("HelloService: Server %d called", count))),
-			// server.WithReadWriteTimeout(100* time.Second),
+			server.WithMiddleware(middleware.ValidatorMW),
 		)
 
 		if err := svr.Run(); err != nil {

--- a/templates/main_tpl.yaml
+++ b/templates/main_tpl.yaml
@@ -53,7 +53,7 @@ body: |-
         }),
         server.WithServiceAddr(addr),
         server.WithMiddleware(middleware.MiddleWareLogger(fmt.Sprintf("{{.ServiceName}}: Server %d called", count))),
-        // server.WithReadWriteTimeout(100* time.Second),
+        server.WithMiddleware(middleware.ValidatorMW),
       )
 
       if err := svr.Run(); err != nil {

--- a/templates/middleware.yaml
+++ b/templates/middleware.yaml
@@ -6,6 +6,7 @@ body: |-
 
   import (
     "context"
+    "fmt"
 
     "github.com/cloudwego/kitex/pkg/endpoint"
     "github.com/cloudwego/kitex/pkg/klog"
@@ -43,6 +44,32 @@ body: |-
       }
       // get real response
       klog.Infof("real response: %+v\n", resp.(result).GetResult())
+      return nil
+    }
+  }
+
+  func ValidatorMW(next endpoint.Endpoint) endpoint.Endpoint {
+    return func(ctx context.Context, args, result interface{}) (err error) {
+      if gfa, ok := args.(interface{ GetFirstArgument() interface{} }); ok {
+        req := gfa.GetFirstArgument()
+        if rv, ok := req.(interface{ IsValid() error }); ok {
+          if err := rv.IsValid(); err != nil {
+            return fmt.Errorf("request data is not valid:%w", err)
+          }
+        }
+      }
+      err = next(ctx, args, result)
+      if err != nil {
+        return err
+      }
+      if gr, ok := result.(interface{ GetResult() interface{} }); ok {
+        resp := gr.GetResult()
+        if rv, ok := resp.(interface{ IsValid() error }); ok {
+          if err := rv.IsValid(); err != nil {
+            return fmt.Errorf("response data is not valid:%w", err)
+          }
+        }
+      }
       return nil
     }
   }


### PR DESCRIPTION
This pull request refactors the HTTP server code to be much smaller.

For all requests to the HTTP server, a single service map keeps track of which generic client to call.
Generated codes are no longer necessary for Hertz, as the client will simply parse the thrift file. Request validation is now done on 
the server side (with changes made to the template generation).